### PR TITLE
Fix for upstream change in 2026.1

### DIFF
--- a/components/electriq_ac/electriq_ac.cpp
+++ b/components/electriq_ac/electriq_ac.cpp
@@ -52,7 +52,7 @@ void ElectriqAC::SendHeartbeat() {
 // Select command nibble for fan speed
 void ElectriqAC::AcFanSpeed() {
   if (this->has_custom_fan_mode()) {
-    const char* mode = this->get_custom_fan_mode();
+    const char* mode = this->get_custom_fan_mode().c_str();
     if (strcmp(mode, FAN_SPEED_1) == 0) fan_speed_ = 0x90;
     else if (strcmp(mode, FAN_SPEED_2) == 0) fan_speed_ = 0xA0;
     else if (strcmp(mode, FAN_SPEED_3) == 0) fan_speed_ = 0xB0;
@@ -257,8 +257,8 @@ void ElectriqAC::control(const climate::ClimateCall &call) {
     // Set fan speed nibble here to avoid unexpected switch-off on temp changes
     AcFanSpeed();
     SendToMCU();
-  } else if (call.get_custom_fan_mode() != nullptr) {
-    const char* mode = call.get_custom_fan_mode();
+  } else if (call.has_custom_fan_mode()) {
+    auto mode = call.get_custom_fan_mode();
     this->set_custom_fan_mode_(mode);
     AcFanSpeed();
     SendToMCU();


### PR DESCRIPTION
Firstly, thank you for this!

I bought one of these units a while back having found this but I've only just had the motivation to get in to the unit to try this.

ESPHome 2026.1 has a [breaking change](https://esphome.io/changelog/2026.10/#breaking-changes-1) which breaks this.

Further info in https://github.com/esphome/esphome/pull/13103.

This ~MR~ PR fixes it, at least it compiles for me and seems to work :D.

As another data point, I bought this in 2023-06 and I'm unable to use the `tuya:` integration.