### PR TITLE
Fix build against current ESPHome API, and a control() bug dropping combined calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+secrets.yaml
+.esphome/
+build/
+*.bin
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This external component for ESPhome replaces the Tuya firmware within the ESP8266 wifi module found inside [Electriq](https://www.electriq.co.uk) branded air conditioning units for integration into Home Assistant. Developed on the 12000 Smart model, others may also be supported.
 
+**Not all Electriq units speak the proprietary protocol this component implements.** A unit purchased 2023/2024 (TYWE1S module, ESP8285H08 chip) turned out to speak the standard, documented Tuya MCU protocol instead - confirmed via checksum verification against its real traffic. If that's what you have, you don't need this custom component at all; see [planestranescars/electriq-ac-tuya](https://github.com/planestranescars/electriq-ac-tuya) for the full writeup, datapoint table, and a ready-to-use config. Quickest way to tell which protocol your unit speaks: flash a bare config with just `uart:` + `tuya:` (no climate platform) and watch the boot log - if it dumps a list of datapoints, use that repo instead of this one.
+
 ## Introduction
 
 The Electriq 12000 BTU WiFi Smart AC with Heat Pump is a portable AC unit sold by (and a brand name of?) https://www.appliancesdirect.co.uk

--- a/components/electriq_ac/electriq_ac.cpp
+++ b/components/electriq_ac/electriq_ac.cpp
@@ -16,6 +16,7 @@ static const char *const FAN_SPEED_5 = "High";
 
 void ElectriqAC::setup() {
   this->set_interval("heartbeat", 1800, [this] { SendHeartbeat(); });
+  this->set_supported_custom_fan_modes({FAN_SPEED_1, FAN_SPEED_2, FAN_SPEED_3, FAN_SPEED_4, FAN_SPEED_5});
 }
 
 // only used during debugging
@@ -105,8 +106,6 @@ bool ElectriqAC::CheckIdle(uint8_t &a) {
 
 // read and parse messages from MCU serial
 void ElectriqAC::ReadMCU() {
-  uint8_t pos = 0;
-  uint8_t csum = 0;
   uint8_t c;
   uint8_t b[16];
   
@@ -123,12 +122,12 @@ void ElectriqAC::ReadMCU() {
       while (this->available()) {
         read_byte(&c);
       }
-      // validate the checksum before progressing
-      while (pos < 14) {
+      // validate the checksum before progressing (sums all bytes except the checksum byte itself)
+      uint8_t csum = 0xAA;
+      for (uint8_t pos = 0; pos < 15; ++pos) {
         csum += b[pos];
-        ++pos;
       }
-      if ((csum += 0xAA) != b[15]) {
+      if (csum != b[15]) {
         ESP_LOGD(TAG, "Bad received checksum %s, should be %s", format_hex_pretty(csum).c_str(),
                  format_hex_pretty(b[15]).c_str());
         return;
@@ -138,11 +137,6 @@ void ElectriqAC::ReadMCU() {
       uint8_t m = (b[1] & 0x0F);
       uint8_t s = (b[2] & 0x0F);
       uint8_t a = (b[11] & 0x0F);
-      static uint8_t last_b1;   // command
-      static uint8_t last_b2;   // swing
-      static uint8_t last_b3;   // set temp
-      static uint8_t last_b7;   // temp probe
-      static uint8_t last_b11;  // active state
 
       if (f == 0x10) {
         ESP_LOGD(TAG, "Detected mode: Standby");
@@ -228,20 +222,21 @@ void ElectriqAC::ReadMCU() {
       target_temp_ = b[3];
 
       // only publish state if something changes
-      if ((last_b1 != b[1]) || (last_b2 != b[2]) || (last_b3 != b[3]) || (last_b7 != b[7]) || (last_b11 != b[11])) {
+      if ((last_b1_ != b[1]) || (last_b2_ != b[2]) || (last_b3_ != b[3]) || (last_b7_ != b[7]) || (last_b11_ != b[11])) {
         ESP_LOGD(TAG, "Publishing new state...");
         this->publish_state();
-        last_b1 = b[1];
-        last_b2 = b[2];
-        last_b3 = b[3];
-        last_b7 = b[7];
-        last_b11 = b[11];
+        last_b1_ = b[1];
+        last_b2_ = b[2];
+        last_b3_ = b[3];
+        last_b7_ = b[7];
+        last_b11_ = b[11];
       }
     }
   }
 }
 
 void ElectriqAC::control(const climate::ClimateCall &call) {
+  bool changed = false;
   if (call.get_mode().has_value()) {
     ESP_LOGD(TAG, "New mode value seen");
     climate::ClimateMode mode = *call.get_mode();
@@ -251,39 +246,40 @@ void ElectriqAC::control(const climate::ClimateCall &call) {
     if (this->mode != climate::CLIMATE_MODE_OFF) {
       AcFanSpeed();
     }
-    SendToMCU();
-  } else if (call.get_target_temperature().has_value()) {
+    changed = true;
+  }
+  if (call.get_target_temperature().has_value()) {
     target_temp_ = *call.get_target_temperature();
     // Set fan speed nibble here to avoid unexpected switch-off on temp changes
     AcFanSpeed();
-    SendToMCU();
-  } else if (call.has_custom_fan_mode()) {
+    changed = true;
+  }
+  if (call.has_custom_fan_mode()) {
     auto mode = call.get_custom_fan_mode();
     this->set_custom_fan_mode_(mode);
     AcFanSpeed();
-    SendToMCU();
-  } else if (call.get_swing_mode().has_value()) {
+    changed = true;
+  }
+  if (call.get_swing_mode().has_value()) {
     climate::ClimateSwingMode swing_mode = *call.get_swing_mode();
     this->swing_mode = swing_mode;
     AcSwing();
     // Set fan speed nibble here to avoid unexpected switch-off on temp changes
     AcFanSpeed();
+    changed = true;
+  }
+  // a single HA service call can carry mode + temperature + fan + swing together;
+  // apply everything present, then send once
+  if (changed) {
     SendToMCU();
   }
 }
 
 climate::ClimateTraits ElectriqAC::traits() {
   auto traits = climate::ClimateTraits();
-  
-  // Using deprecated methods - they still work, just show warnings
-  // The replacement API varies by ESPHome version, update in future.
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  traits.set_supports_action(true);
-  traits.set_supports_two_point_target_temperature(false);
-  traits.set_supports_current_temperature(true);
-  #pragma GCC diagnostic pop
-  
+
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION | climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+
   traits.set_visual_min_temperature(16);
   traits.set_visual_max_temperature(32);
   traits.set_visual_temperature_step(1);
@@ -292,14 +288,6 @@ climate::ClimateTraits ElectriqAC::traits() {
                               climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY});
 
   traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL});
-
-  traits.set_supported_custom_fan_modes({
-    FAN_SPEED_1,
-    FAN_SPEED_2,
-    FAN_SPEED_3,
-    FAN_SPEED_4,
-    FAN_SPEED_5
-  });
 
   return traits;
 }

--- a/components/electriq_ac/electriq_ac.h
+++ b/components/electriq_ac/electriq_ac.h
@@ -28,6 +28,13 @@ class ElectriqAC : public climate::Climate, public Component, public uart::UARTD
   uint8_t fan_speed_ = 0x90;
   uint8_t swing_ = 0;
   uint8_t target_temp_ = 0;
+
+  // last-seen MCU status bytes, used to suppress redundant publish_state() calls
+  uint8_t last_b1_ = 0;
+  uint8_t last_b2_ = 0;
+  uint8_t last_b3_ = 0;
+  uint8_t last_b7_ = 0;
+  uint8_t last_b11_ = 0;
 };
 
 }  // namespace electriq_ac


### PR DESCRIPTION
## Summary

- **Build fix**: `ClimateTraits::set_supports_action()` / `set_supports_two_point_target_temperature()` / `set_supports_current_temperature()` were removed in ESPHome 2026.5.0 - this component currently doesn't compile on any recent ESPHome install. Replaced with the current `add_feature_flags()` API. Verified with a clean local build against 2026.6.5.
- **`control()` bug**: it used an `else if` chain across mode/temperature/fan/swing, so a single Home Assistant call that sets more than one of these at once (e.g. mode + temperature together, which HA's climate services legitimately do in one call) silently dropped everything after the first matched field. Now applies every field present in a call, then sends once.
- Moved custom fan mode registration from `traits()` to `setup()`, per the 2026.4.0 deprecation notice - avoids rebuilding the fan mode list on every `publish_state()`/`control()` call.
- Fixed the checksum validation range, which was omitting the last data byte before the checksum byte itself.
- Moved the last-seen-status tracking variables from function-local `static` to member variables, so they can't end up shared across multiple instances of the component.
- Added a README note and a `.gitignore` (secrets/build artifacts weren't excluded before).

## Not included

I also hit this component while investigating a different Electriq unit (2023/2024, TYWE1S module) that turned out to speak the *standard* Tuya MCU protocol rather than this proprietary one - documented separately at [planestranescars/electriq-ac-tuya](https://github.com/planestranescars/electriq-ac-tuya), and linked from the README here. While debugging that, I also tried making `ReadMCU()` process a full UART backlog instead of one frame plus discard, with resync-on-bad-checksum instead of aborting. I'm leaving that change out of this PR: it's a reasonable idea on paper, but since my test unit didn't actually speak this proprietary protocol, I have no real traffic to validate it against. Didn't want to hand you an unverified "fix" for a code path I couldn't actually test.

## Test plan

- [x] Clean local build against ESPHome 2026.6.5 with the external component pointed at this branch (previously failed with "no member named 'set_supports_action'")
- [ ] Flash to real proprietary-protocol hardware to confirm behavior is otherwise unchanged (I don't have access to a unit that speaks this protocol - my unit turned out to be the standard-protocol variant above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>